### PR TITLE
Fix two broken link to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-<p align="center"><img src="https://flarum.org/img/logo.png"></p>
-<p align="center"><img src="https://www.docker.com/sites/default/files/d8/2019-07/vertical-logo-monochromatic.png" style="max-width:150px"></p>
+<p align="center">
+  <a href="https://flarum.org">
+    <img src="https://user-images.githubusercontent.com/19341857/181917693-c9391c43-65f3-4986-a972-97012404f6ed.svg" width="300">
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://www.docker.com">
+    <img src="https://www.docker.com/sites/default/files/d8/2019-07/vertical-logo-monochromatic.png" width="300">
+  </a>
+</p>
 
 
 ## About this project

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All Flarum settings are default, except
 
 * **Powerful and extensible.** Customize, extend, and integrate Flarum to suit your community. Flarum’s architecture is amazingly flexible, with a powerful Extension API.
 
-![screenshot](https://flarum.org/img/screenshot.png)
+![screenshot](https://user-images.githubusercontent.com/19341857/195999533-a1b268d4-e572-4985-9117-21bde128ff70.png)
 
 ## Installation
 


### PR DESCRIPTION
1. The link to Flarum logo was broken, so it's being replaced with a new link, which is
![flarum.svg](https://user-images.githubusercontent.com/19341857/181917693-c9391c43-65f3-4986-a972-97012404f6ed.svg)

2. Decrease the Docker size so that both Flarum logo and Docker logo have the same width.

3. Link the Docker logo with https://docker.com/

4. The link to `screenshot.png` was broken, so it's updated to:
![screenshot.png](https://user-images.githubusercontent.com/19341857/195999533-a1b268d4-e572-4985-9117-21bde128ff70.png)